### PR TITLE
Add support for Swift Package Manager 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,9 +2,9 @@
 import PackageDescription
 
 let package = Package(
-    name: "Zendesk Sunshine Conversations",
+    name: "Smooch",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v8)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
     products: [
         .library(
             name: "Smooch",
-            type: .dynamic,
             targets: ["Smooch"])
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(
             name: "Smooch",
+            type: .dynamic,
             targets: ["Smooch"])
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "Zendesk Sunshine Conversations",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "Smooch",
+            targets: ["Smooch"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "Smooch",
+            path: "Smooch.xcframework"
+        )
+    ]
+)


### PR DESCRIPTION
This simply adds a `Package.swift` which defines a binary target

Maybe the naming needs to be adjusted.